### PR TITLE
Bugfix: Avoid race condition by using multiple keys to store session and participants

### DIFF
--- a/PlanningPoker.Server/SessionHub.cs
+++ b/PlanningPoker.Server/SessionHub.cs
@@ -5,7 +5,7 @@ namespace PlanningPoker.Server;
 
 public class SessionHub(IDatabase database) : Hub<ISessionHubClient>, ISessionHub
 {
-    private async Task<Session> GetSessionNewAsync(Guid sessionId)
+    private async Task<Session> GetSessionAsync(Guid sessionId)
     {
         var participantIds = await database.ListRangeAsync($"{sessionId}:participants");
         var participantKeys = participantIds.Select(i => $"{sessionId}:participants:{i}");
@@ -59,7 +59,7 @@ public class SessionHub(IDatabase database) : Hub<ISessionHubClient>, ISessionHu
 
         await Groups.AddToGroupAsync(Context.ConnectionId, sessionId.ToString());
 
-        return await GetSessionNewAsync(sessionId) ?? throw new Exception($"Unable to read session {sessionId}.");
+        return await GetSessionAsync(sessionId) ?? throw new Exception($"Unable to read session {sessionId}.");
     }
 
     public async Task<Guid> CreateSessionAsync(string title)
@@ -182,7 +182,7 @@ public class SessionHub(IDatabase database) : Hub<ISessionHubClient>, ISessionHu
         }
         else
         {
-            var session = await GetSessionNewAsync(sessionId);
+            var session = await GetSessionAsync(sessionId);
             await Clients.Group(sessionId.ToString()).OnReveal(session.Participants);
         }
     }


### PR DESCRIPTION
This fixes issue #1 by splitting the session across multiple keys. One key for the session info (title, state), one key for a list containing the IDs of the participants, then one key per participant. This isolates participant updates to only update the key associated with that participant data, and uses hashes to only update the fields being updated.