### PR TITLE
Add reconnect/disconnect logic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+csharp_new_line_before_open_brace = none

--- a/PlanningPoker.Client/Pages/SessionPage.razor
+++ b/PlanningPoker.Client/Pages/SessionPage.razor
@@ -11,6 +11,11 @@
         <span class="visually-hidden">Loading...</span>
     </div>
 }
+else if (_state.IsClosed) {
+    <div style="position: absolute; left: 50%; top: 50%; margin-top:-3rem; margin-left: -3rem; width: 6rem; height: 6rem;" role="status">
+        ⚠️ You've been disconnected! Please refresh this page to reconnect.
+    </div>
+}
 else {
     <ToastComponent />
     <JoinFormComponent />

--- a/PlanningPoker.Server/IStore.cs
+++ b/PlanningPoker.Server/IStore.cs
@@ -10,6 +10,7 @@ public interface IStore {
     Task IncrementParticipantStarsAsync(string sessionId, string participantId, int count = 1);
     Task RemovePointAsync(string sessionId, string point);
     Task UpdateAllParticipantPointsAsync(string sessionId, string points = "");
+    Task UpdateParticipantId(string sessionId, string oldParticipantId, string newParticipantId);
     Task UpdateParticipantNameAsync(string sessionId, string participantId, string name);
     Task UpdateParticipantPointsAsync(string sessionId, string participantId, string points);
     Task UpdateSessionStateAsync(string sessionId, State state);

--- a/PlanningPoker.Server/InMemoryStore.cs
+++ b/PlanningPoker.Server/InMemoryStore.cs
@@ -10,18 +10,18 @@ public class InMemoryStore : IStore {
     }
 
     private static Task UpdateParticipant(string sessionId, string participantId, Func<Participant, Participant> update) {
-        var participant = _sessions[sessionId].Participants.SingleOrDefault(p => p.ParticipantId == participantId);
-        return UpdateSession(sessionId, session => session with { Participants = [ ..session.Participants.Except([participant]), update(participant!) ] });
+        var participant = _sessions[sessionId].Participants.Single(p => p.ParticipantId == participantId);
+        return UpdateSession(sessionId, session => session with { Participants = [.. session.Participants.Except([participant]), update(participant!)] });
     }
 
     public Task CreateParticipantAsync(string sessionId, string participantId, string name) =>
         UpdateSession(sessionId, session => session with {
-            Participants = [..session.Participants, new(participantId, name, "", 0) ]
+            Participants = [.. session.Participants, new(participantId, name, "", 0)]
         });
 
     public Task AddPointAsync(string sessionId, string point) =>
         UpdateSession(sessionId, session => session with {
-            Points = [..session.Points, point]
+            Points = [.. session.Points, point]
         });
 
     public Task<string> CreateSessionAsync(string title, IEnumerable<string> points) {
@@ -60,7 +60,12 @@ public class InMemoryStore : IStore {
 
     public Task UpdateAllParticipantPointsAsync(string sessionId, string points = "") =>
         UpdateSession(sessionId, session => session with {
-            Participants = session.Participants.Select(p => p with { Points = points}).ToArray()
+            Participants = session.Participants.Select(p => p with { Points = points }).ToArray()
+        });
+
+    public Task UpdateParticipantId(string sessionId, string oldParticipantId, string newParticipantId) =>
+        UpdateParticipant(sessionId, oldParticipantId, participant => participant with {
+            ParticipantId = newParticipantId
         });
 
     public Task UpdateParticipantNameAsync(string sessionId, string participantId, string name) =>

--- a/PlanningPoker/ISessionHub.cs
+++ b/PlanningPoker/ISessionHub.cs
@@ -8,6 +8,7 @@ public interface ISessionHub {
     Task DisconnectFromSessionAsync(string sessionId);
     Task RemovePointAsync(string sessionId, string point);
     Task SendStarToParticipantAsync(string sessionId, string participantId);
+    Task<Session> UpdateParticipantIdAsync(string sessionId, string oldParticipantId);
     Task UpdateParticipantPointsAsync(string sessionId, string points);
     Task UpdateSessionStateAsync(string sessionId, State state);
     Task UpdateSessionTitleAsync(string sessionId, string title);

--- a/PlanningPoker/ISessionHubClient.cs
+++ b/PlanningPoker/ISessionHubClient.cs
@@ -2,6 +2,7 @@
 
 public interface ISessionHubClient {
     Task OnParticipantAdded(string participantId, string name);
+    Task OnParticipantIdUpdated(string oldParticipantId, string newParticipantId);
     Task OnParticipantNameUpdated(string participantId, string name);
     Task OnParticipantPointsUpdated(string participantId, string points);
     Task OnParticipantRemoved(string participantId);


### PR DESCRIPTION
When clients reconnect, they get a new conneection id and get booted from previous groups. This PR adds:

* Client events handling Reconnecting, Reconnected, and Closed events, updating state and making server callbacks
* Sever event handling client disconnected event, notifying other clients of the disconnection
* Server callback to update the participant ID and re-sync state, and
* Client callback to update participant ID

Visually, this only adds a notification to the user in the event that they become entirely disconnected. Visual approach to notify client of reconnecting should be considered.

Have yet to thoroughly test. Will be difficult.