### PR TITLE
Feature: Stateless Server

### DIFF
--- a/PlanningPoker.Server/Program.cs
+++ b/PlanningPoker.Server/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.SignalR;
 using PlanningPoker.Server;
 using StackExchange.Redis;
 
@@ -34,6 +35,8 @@ else {
 }
 
 signalRBuilder.AddMessagePackProtocol();
+
+builder.Services.AddSingleton<IUserIdProvider, SessionHub.UserIdProvider>();
 
 builder.Services.AddRazorPages();
 

--- a/PlanningPoker/ISessionHub.cs
+++ b/PlanningPoker/ISessionHub.cs
@@ -4,7 +4,7 @@ public interface ISessionHub {
     Task AddPointAsync(string sessionId, string point);
     Task<Session> ConnectToSessionAsync(string sessionId);
     Task<string> CreateSessionAsync(string title, IEnumerable<string> points);
-    Task<string> JoinSessionAsync(string sessionId, string name);
+    Task JoinSessionAsync(string sessionId, string name);
     Task DisconnectFromSessionAsync(string sessionId);
     Task RemovePointAsync(string sessionId, string point);
     Task SendStarToParticipantAsync(string sessionId, string participantId);


### PR DESCRIPTION
Generally speaking it's better practice to have a stateless server. This requires more logic on both the server and client to handle, but will ultimately lead to a more robust reconnectino strategy than the current stateful approach.

With the current stateful approach, the same connection id (saved in memory on the server) is used by a client after reconnecting. This only works so long as the server stays alive - not always true during catastrophic failures (causing containers to restart) or deployments.

Sticky sessions could ameliorate the issue with deployments but not the issue with catastrophic failures. Therefore, it will be better to implement custom reconnect/sync logic.